### PR TITLE
docs fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,8 @@
 
 # Hide doxygen output from repo 
 docs/build/
-docs/latex/
-docs/source/xml/
-docs/doxyoutput
-docs/api
+docs/source/_doxygen
+docs/source/api
 
 # Hide extern
 extern/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,23 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile clean
+
+clean:
+	rm -rf source/_doxygen source/api
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       =
+OUTPUT_DIRECTORY       = _doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -162,7 +162,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = ..
+STRIP_FROM_PATH        = ../../BattleNetwork
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -815,50 +815,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f \
-                         *.for \
-                         *.tcl \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf
+FILE_PATTERNS          = *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,11 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os 
+import os
+import re
 import sys
-#import subprocess
-#subprocess.call('cd ../.. ; doxygen doxygenfile', shell=True)
-
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -30,12 +28,10 @@ release = '1'
 
 # -- General configuration ---------------------------------------------------
 
-sys.path.append("../breathe")
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['breathe', 'exhale'
-]
+extensions = ['breathe', 'exhale']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -51,53 +47,75 @@ exclude_patterns = []
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path   = ['_static']
+html_theme         = 'bootstrap'
+html_favicon       = 'favicon.gif'
+html_logo          = 'favicon.gif'
+html_theme         = 'bootstrap'
+html_theme_options = {
+    'navbar_site_name': "Open MMBN",
+    'navbar_links': [
+        ("Contributing", "https://github.com/TheMaverickProgrammer/battlenetwork/wiki/Contributing", True)
+    ],
+    'source_link_position': "exclude",
+    'navbar_class': "navbar",
+    'navbar_fixed_top': "true",
+    'navbar_sidebarrel': False,  # Exhale does not support next / previous well
+    'bootswatch_theme': "sandstone",
+    'bootstrap_version': "3",
+}
 
 # -- Breathe setup -----------------------------------------------------------
-breathe_projects = { "C++ MMBN Project": "xml" }
-breathe_default_project = "C++ MMBN Project"
+# NOTE: see also, OUTPUT_DIRECTORY and XML_OUTPUT_DIRECTORY in Doxyfile.
+# If those change, this must update.
+this_file_dir = os.path.dirname(os.path.abspath(__file__))
+breathe_projects = {project: os.path.join(this_file_dir, '_doxygen', 'xml')}
+breathe_default_project = project
+
+# Tell sphinx not to process the doxygen output directory when searching for
+# files to render into html.
+exclude_patterns = ['_doxygen/**']
 
 # -- Exhale setup ------------------------------------------------------------
 exhale_args = {
-        "containmentFolder": "./api",
-        "rootFileName":      "library_root.rst",
-        "rootFileTitle":     "Code",
-        "doxygenStripFromPath": "../../BattleNetwork",
-        "createTreeView":    True,
-        "exhaleExecutesDoxygen": True,
-        # "exhaleDoxygenStdin": "INPUT = ../../BattleNetwork",
-        "exhaleUseDoxyfile": True,
-        "unabridgedOrphanKinds": {"dir", "file" }
-        }
+    "containmentFolder": "./api",
+    "rootFileName": "library_root.rst",
+    "rootFileTitle": "Code",
+    # NOTE: see STRIP_FROM_PATH in Doxyfile.  If that updates, this must too.
+    "doxygenStripFromPath": "../../BattleNetwork",
+    "fullToctreeMaxDepth": 1,
+    # See edits in source_read.  This tricks Exhale into not including a
+    # top-level "Full API" heading on the unabridged document.
+    "fullApiSubSectionTitle": "",
+    "createTreeView": False,  # See source_read, they get pruned.
+    "exhaleExecutesDoxygen": True,
+    "exhaleUseDoxyfile": True,
+    "unabridgedOrphanKinds": {"dir"}
+}
 
 primary_domain = 'cpp'
-
 highlight_language = 'cpp'
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-html_favicon = 'favicon.gif'
-html_logo    = 'favicon.gif'
-html_theme   = 'bootstrap'
-html_theme_options = {
-        'navbar_site_name': "Open MMBN",
-        'navbar_links': [
-            ("Contributing", "https://github.com/TheMaverickProgrammer/battlenetwork/wiki/Contributing", True)
-            ],
+def source_read(app, docname, source):
+    # NOTE: these patches should work until exhale 1.x is released.
 
-        'source_link_position': "exclude",
+    # source is a length one list with it's single element being the source
+    # of the file being processed.  Modify source[0] to change what Sphinx
+    # will render.
 
-        'navbar_class': "navbar",
+    # Delete both view hierarchies since this project has a mostly flat
+    # structure.  Rely on the unabridged API instead.
+    if docname == "api/library_root":
+        source[0] = re.sub(
+            r"\.\. include:: .*_view_hierarchy.rst", "", source[0]
+        )
 
-        'navbar_fixed_top': "true",
+    # Orphan the view hierarchy documents since they aren't used anymore.
+    if docname in {"api/class_view_hierarchy", "api/file_view_hierarchy"}:
+        source[0] = ":orphan:\n\n" + source[0]
 
-        'bootswatch_theme': "sandstone",
 
-        'bootstrap_version': "3",
-        }
-
-if not on_rtd:
-    import sphinx_bootstrap_theme
-    html_theme = 'bootstrap'
-    html_theme_path = [sphinx_bootstrap_theme.get_html_theme_path()]
+# Called by sphinx automatically.
+def setup(app):
+    app.connect("source-read", source_read)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,6 @@ Welcome to C++ MMBN Engine's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   about
    api/library_root
 
 Indices and tables


### PR DESCRIPTION
- only document headers
- coordinate doxygen / sphinx / exhale config variables

> https://github.com/svenevs/exhale/pull/67#issuecomment-495818090
>
> still fails silently at the same step

It may have been a couple of things.  I just pushed something on the branch you've been helping me test to get past something I don't know what to do about.  Your docs build will have

```
(!) Unabridged API: unexpected kind 'page' (IGNORED) 
```

I don't know where `page` is coming from or what to do with it so I just skip it.

I don't think that was the problem, that would have had an actual `KeyError`.  I've fixed a handful of things here, the most important being telling Doxygen to only process the header files and coordinating Doxygen and exhale (e.g., STRIP_FROM_PATH discrepancies).  Your project is large, and there is a known problem with breathe via minidom for large projects: memory leaks.  Reducing to headers only may enable you to get past this.

If you need to bring one or two back you should do that file explicitly in the `INPUT` field.  Example

```make
INPUT = ../../BattleNetwork \
        ../../BattleNetwork/some_file.cpp
```

Basically, your project is big enough that you may not actually be able to build it on RTD at all.  The typical solution in this case is to setup Travis CI or Azure Pipelines or any other CI service provider, build your docs there, then push to a github pages site.  But hopefully with this PR you won't fail on that.  RTD used to signal that the job was killed but now we can only guess :/

> https://github.com/svenevs/exhale/issues/65#issuecomment-495229599
>
> now if only I could see the entire source stub before processing maybe I could write some more modifications. :)

Sorry for not making that a little clearer.  Since you have a `"containmentFolder"` of `api`, just look in there.  The key files from exhale are

- `api/library_root.rst`
    - includes `api/class_view_hierarchy.rst`
    - includes `api/file_view_hierarchy.rst`
    - includes `api/unabridged_api.rst`

So once you `make html` once, you can just peruse the `docs/source/api` folder :)

I'll add some review comments to cover the specific changes and why.