### PR TITLE
Adding tile:set_team, adjusting some font stuff

### DIFF
--- a/BattleNetwork/bnCardSelectionCust.cpp
+++ b/BattleNetwork/bnCardSelectionCust.cpp
@@ -119,6 +119,7 @@ CardSelectionCust::CardSelectionCust(const CardSelectionCust::Props& props) :
   codeFont(Font::Style::wide),
   codeFont2(Font::Style::small),
   label("", labelFont),
+  damageLabel("", labelFont),
   smCodeLabel("?", codeFont)
 {
   this->props.cap = std::min(this->props.cap, 8);
@@ -221,6 +222,7 @@ CardSelectionCust::CardSelectionCust(const CardSelectionCust::Props& props) :
 
   //setScale(0.5f, 0.5); // testing transforms
   label.setScale(2.f, 2.f);
+  damageLabel.setScale(2.1, 2.1);
   smCodeLabel.setScale(2.f, 2.f);
 }
 
@@ -792,23 +794,24 @@ void CardSelectionCust::draw(sf::RenderTarget & target, sf::RenderStates states)
 
       // card name font shadow
       const std::string& shortname = queue[cursorPos + (5 * cursorRow)].data->GetShortName();
-      label.setPosition((offset + 2.f * 16.f) + 2.f, 22.f);
+      label.setPosition((offset + 2.f * 16.f) + 2.f, 26.f);
       label.SetString(shortname);
       label.SetColor(sf::Color(80, 75, 80));
       target.draw(label, states);
 
       // card name font overlay
-      label.setPosition(offset + 2.f * 16.f, 20.f);
+      label.setPosition(offset + 2.f * 16.f, 24.f);
       label.SetString(shortname);
-      label.SetColor(sf::Color::White);
+      label.SetColor(sf::Color(224, 224, 224, 255));
+      damageLabel.SetColor(sf::Color(224, 224, 224, 255));
       target.draw(label, states);
 
       // the order here is very important:
       if (queue[cursorPos + (5 * cursorRow)].data->GetDamage() > 0) {
-        label.SetString(std::to_string(queue[cursorPos + (5 * cursorRow)].data->GetDamage()));
+        damageLabel.SetString(std::to_string(queue[cursorPos + (5 * cursorRow)].data->GetDamage()));
         label.setOrigin(label.GetLocalBounds().width + label.GetLocalBounds().left, 0);
-        label.setPosition((offset + 2.f * (70.f)) + 2.f, 152.f);
-        target.draw(label, states);
+        damageLabel.setPosition(((offset-28.f) + 2.f * (70.f)) + 2.f, 150.f);
+        target.draw(damageLabel, states);
       }
 
       label.setOrigin(0, 0);

--- a/BattleNetwork/bnCardSelectionCust.h
+++ b/BattleNetwork/bnCardSelectionCust.h
@@ -80,6 +80,7 @@ private:
   Font codeFont, codeFont2;
   mutable Text smCodeLabel;
   mutable Text label;
+  mutable Text damageLabel;
   mutable CustEmblem emblem;
 
   int formCursorRow; //!< Cursor row

--- a/BattleNetwork/bnMegaman.cpp
+++ b/BattleNetwork/bnMegaman.cpp
@@ -37,8 +37,6 @@ Megaman::Megaman() : Player() {
 
   // First sprite on the screen should be default player stance
   SetAnimation("PLAYER_IDLE");
-
-  SetEmotion(Emotion::evil);
 }
 
 Megaman::~Megaman()

--- a/BattleNetwork/bnPlayerHealthUI.cpp
+++ b/BattleNetwork/bnPlayerHealthUI.cpp
@@ -20,7 +20,7 @@ PlayerHealthUI::PlayerHealthUI(Player* _player) :
   uibox.setScale(2.f, 2.f);
 
   glyphs.setScale(2.f, 2.f);
-  glyphs.setPosition((uibox.getLocalBounds().width*2.f) - 8.f, 4.f);
+  glyphs.setPosition((uibox.getLocalBounds().width*2.f) - 8.f, 6.f);
 
   lastHP = currHP = startHP = _player->GetHealth();
 

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -283,6 +283,7 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
     "is_hidden", &Battle::Tile::IsHidden,
     "is_reserved", &Battle::Tile::IsReservedByCharacter,
     "get_team", &Battle::Tile::GetTeam,
+	"set_team", &Battle::Tile::SetTeam,
     "attack_entities", &Battle::Tile::AffectEntities,
     "get_distance_to_tile", &Battle::Tile::Distance,
     "find_characters", &Battle::Tile::FindCharacters,


### PR DESCRIPTION
-Resized the damage number on cards in cust screen, required a new label.
-Recolored the name of cards to 224,224,224 instead of 255,255,255
-Removed Megaman being forced to be evil at the start of battle??? Sorry if this was temporarily intentional.
-Fixed Player Health UI Glyph alignment
-Re-Exposed Tile::setTeam to scripting.